### PR TITLE
fix: source the script instead of executing

### DIFF
--- a/tasks/preparation-provisioning.yaml
+++ b/tasks/preparation-provisioning.yaml
@@ -89,4 +89,5 @@ spec:
         export AZURE_TENANT_ID
         export AZURE_SUBSCRIPTION_ID
         export AZURE_RESOURCE_GROUP
-        /images_db_stub.sh 
+
+        source /images_db_stub.sh 


### PR DESCRIPTION
The script might not be executable, it's better to source it.