### PR TITLE
Adding results in noop.yaml

### DIFF
--- a/tasks/noop.yaml
+++ b/tasks/noop.yaml
@@ -8,3 +8,6 @@ spec:
       image: ubuntu
       command: [echo]
       args: ["No preparation step needed"]
+  results:
+    - name: iqe-additional-env-vars
+      description: ""


### PR DESCRIPTION
Error - invalid result reference in pipeline task "run-iqe-cji": "iqe-additional-env-vars" is not a named result returned by pipeline task "custom-preparation"






