### PR TITLE
Output empty result

### DIFF
--- a/tasks/noop.yaml
+++ b/tasks/noop.yaml
@@ -3,11 +3,14 @@ kind: Task
 metadata:
   name: noop
 spec:
-  steps:
-    - name: noop-preparation
-      image: ubuntu
-      command: [echo]
-      args: ["No preparation step needed"]
   results:
     - name: iqe-additional-env-vars
       description: ""
+  steps:
+    - name: noop-preparation
+      image: ubuntu
+      script: |
+        #!/bin/bash
+        echo "Noop - skipping - no preparation needed"
+
+        echo -n "" > $(results.iqe-additional-env-vars.path)


### PR DESCRIPTION
The result definition seem to have enabled the pipeline to run, but the task requiring the output have failed to start.

This might fix it by creating actual empty result.