### PR TITLE
fix: aritifacts upload script

### DIFF
--- a/tasks/teardown.yaml
+++ b/tasks/teardown.yaml
@@ -87,7 +87,7 @@ spec:
         set -ex
 
         echo "Copying files to S3"
-        ./upload-to-s3.sh | tee "$(results.ARTIFACTS_URL.path)"
+        upload-to-s3.sh | tee "$(results.ARTIFACTS_URL.path)"
 
     - name: release-namespace
       image: "$(params.BONFIRE_IMAGE)"


### PR DESCRIPTION
The scripts are in path, but not directly in the working directory. This calls the script from path.