### PR TITLE
Bump memory for the iqe-cji task

### DIFF
--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -152,3 +152,10 @@ spec:
 
         echo "Deploying the IQE CJI test"
         deploy-iqe-cji.sh "$(params.NS)" "$(params.NS_REQUESTER)"
+      computeResources:
+        requests:
+          memory: 2Gi
+          cpu: 500m
+        limits:
+          memory: 3Gi
+          cpu: 800m


### PR DESCRIPTION
The cji task need some more memory to be functional